### PR TITLE
version base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:10.6.0-alpine
 WORKDIR /app
 COPY ./package* ./
 RUN npm install


### PR DESCRIPTION
In older versions of node images, spread syntax will not work which is used by [mesg-js](https://github.com/mesg-foundation/mesg-js/blob/master/lib/service/listenTask.js#L12).

I'll convert mesg-js to TypeScript and we'll use postinstall script to transpile our code to ecma5. So this issue will disappear in future but  it's always a good practice to version our base images.